### PR TITLE
Increase performance using cache for providers

### DIFF
--- a/lib/data_provider/base.rb
+++ b/lib/data_provider/base.rb
@@ -59,11 +59,11 @@ module DataProvider
       end
 
       def take(id, opts = {})
-        dpc.take(id, opts.merge(:scope => self))
+        dpc.take(id, opts.merge!(:scope => self))
       end
 
       def try_take(id, opts = {})
-        dpc.try_take(id, opts.merge(:scope => self))
+        dpc.try_take(id, opts.merge!(:scope => self))
       end
 
       def got?(*args)
@@ -147,7 +147,7 @@ module DataProvider
 
       def add_scoped! _module, options = {}
         if _module.is_a?(DataProvider::Container)
-          dpc.add_scoped!(_module, options) 
+          dpc.add_scoped!(_module, options)
         else
           dpc.add_scoped! _module.dpc, options
         end
@@ -234,20 +234,20 @@ module DataProvider
             include _module
           end
         end
-        
+
         return self
       end
 
       def add_scoped! _module, options = {}
         if _module.is_a?(DataProvider::Container)
-          dpc.add_scoped!(_module, options) 
+          dpc.add_scoped!(_module, options)
         else
           dpc.add_scoped! _module.dpc, options
           self.class.class_eval do
             include _module
           end
         end
-        
+
         return self
       end
     end # module InstanceMethods

--- a/lib/data_provider/container.rb
+++ b/lib/data_provider/container.rb
@@ -165,7 +165,7 @@ module DataProvider
     # take_super is only meant to be called form inside a provider
     # returns the result of next provider with the same ID
     def take_super(opts = {})
-      take(provider_id, opts.merge(:skip => current_skip + 1))
+      take(provider_id, opts.merge!(:skip => current_skip + 1))
     end
 
     #
@@ -334,7 +334,8 @@ module DataProvider
       # if the array is empty, args will always turn out nil
       args = matching_provider_args[opts[:skip].to_i]
 
-      return args.nil? ? nil : Provider.new(*args)
+      @providers_cache[key] = args.nil? ? nil : Provider.new(*args)
+      @providers_cache[key]
     end
   end # class Container
 end # module DataProvider

--- a/lib/data_provider/container.rb
+++ b/lib/data_provider/container.rb
@@ -19,7 +19,6 @@ module DataProvider
     def initialize _opts = {}
       @options = _opts.is_a?(Hash) ? _opts : {}
       @providers_cache = {}
-      @providers_index = {}
     end
 
     def logger
@@ -86,8 +85,7 @@ module DataProvider
     end
 
     def providers
-      # only flatten one level deep
-      @providers_index.values.flatten!(1) || []
+      return @providers || []
     end
 
     def provider_missing &block
@@ -309,11 +307,8 @@ module DataProvider
   private
 
     def add_provider(identifier, opts = {}, block = nil)
-      if !@providers_index[identifier]
-        @providers_index[identifier] = []
-      end
-
-      @providers_index[identifier].unshift([identifier, opts, block])
+      @providers ||= []
+      @providers.unshift [identifier, opts, block]
     end
 
     def add_provides _provides = {}
@@ -335,7 +330,7 @@ module DataProvider
       end
 
       # get all matching providers
-      matching_provider_args = @providers_index[id] || []
+      matching_provider_args = providers.find_all{|args| args.first == id}
       # sort providers on priority, form high to low
       matching_provider_args.sort! do |args_a, args_b|
         # we want to sort from high priority to low, but providers with the same priority level


### PR DESCRIPTION
I managed to get delivery's pipeline another 3 minutes faster with this, in addition to https://github.com/IndependentIP/xsd-reader/pull/2. 

Both PRs combined it's almost twice as fast as seen here: https://jenkins.fuga.com/blue/organizations/jenkins/delivery-pipeline/detail/perf/3/pipeline

The main change here is caching built providers using their id and option as a stringified key, in a local cache. This can probably be vastly improved but already saves quite some time.