### PR TITLE
Ignore private symbolized providers in has_filled_providers check

### DIFF
--- a/data-provider.gemspec
+++ b/data-provider.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "data-provider-fuga"
-  s.version = '0.2.4'
+  s.version = '0.2.5'
   s.files = `git ls-files`.split($/)
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]

--- a/lib/data_provider/container.rb
+++ b/lib/data_provider/container.rb
@@ -58,6 +58,8 @@ module DataProvider
       return false unless has_providers_with_scope?(current_stack)
 
       providers_with_scope(current_stack).sort_by{ |prov_id| prov_id.size }.each do |provider_id|
+        return false if provider_id.last.is_a?(Symbol) # Ignore private symbolized providers for this check.
+
         content_data = try_take(provider_id, opts)
         return true if !content_data.nil? && !(content_data.is_a?(XsdPopulator::Informer) && content_data.skip?) && (content_data.respond_to?(:any?) ? content_data.any? : true)
       end


### PR DESCRIPTION
Some context:

- I ran in to this while trying to add a symbolised provider to hold the video_preview_link_description.
- Providers containing a symbolised provider_id are considered to hold private data that is not taken into consideration when looping through the XSD
- This initially caused an empty `<ResourceGroupContentItem>` node to be built, because we have the following in the XSD-Populator:
```
if element.child_elements_or_choices?
      return element.choice? || content.respond_to?(:try_take) || build_node_without_provider? || 
      provider.has_filled_providers_with_scope?(stack + [element.name]) || provider.force_build_node?(stack + [element.name])
end
```

for the `provider.has_filled_providers_with_scope?(stack + [element.name])` the presence of the newly added symbolised provider made this check return true which in turn caused us to build the empty `<ResourceGroupContentItem>` node.

- Since symbolised providers are always considered to only hold private data that is not relevant for if certain nodes in the XSD should be built, we can and should safely ignore these providers when checking if we should continue building nodes in that branch